### PR TITLE
Skip CSS rules for Firefox

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -693,6 +693,8 @@
             }
 
             function getCssRules(styleSheets) {
+                if (navigator.userAgent.includes('Firefox')) return [];
+
                 var cssRules = [];
                 styleSheets.forEach(function (sheet) {
                     try {


### PR DESCRIPTION
Trying to access `cssRules` on Firefox just crashes the whole process of turning dom into an image. This is an issue in Chrome too but Chrome somehow deals with it internally. 

Related issue: https://github.com/tsayen/dom-to-image/issues/13